### PR TITLE
Add validation to ensure password does not match email to secure_validatable

### DIFF
--- a/config/locales/by.yml
+++ b/config/locales/by.yml
@@ -3,6 +3,7 @@ by:
     messages:
       taken_in_past: 'ужо раней выкарыстоўваўся.'
       equal_to_current_password: 'павінен адрознівацца ад сучаснага пароля.'
+      equal_to_email: 'павінна адрознівацца ад электроннай пошты.'
       password_complexity:
         digit:
           one: 'павінен утрымліваць хоць адну лічбу'

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -3,6 +3,7 @@ cs:
     messages:
       taken_in_past: bylo již použito v minulosti.
       equal_to_current_password: se musí lišit od aktuálního hesla.
+      equal_to_email: musí být jiný než e-mail.
       password_complexity:
         digit:
           one: musí obsahovat alespoň jednu číslici

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -3,6 +3,7 @@ de:
     messages:
       taken_in_past: 'wurde bereits in der Vergangenheit verwendet.'
       equal_to_current_password: 'darf nicht dem aktuellen Passwort entsprechen.'
+      equal_to_email: 'darf nicht dem E-mail entsprechen.'
       password_complexity:
         digit:
           one: muss mindestens eine Ziffer enthalten

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,6 +3,7 @@ en:
     messages:
       taken_in_past: 'was used previously.'
       equal_to_current_password: 'must be different than the current password.'
+      equal_to_email: 'must be different than the email.'
       password_complexity:
         digit:
           one: must contain at least one digit

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -3,6 +3,7 @@ es:
     messages:
       taken_in_past: 'la contraseña fue usada previamente, por favor elige otra.'
       equal_to_current_password: 'tiene que ser diferente a la contraseña actual.'
+      equal_to_email: 'tiene que ser diferente al email'
       password_complexity:
         digit:
           one: tiene que contener al menos un dígito

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -3,6 +3,7 @@ fa:
     messages:
       taken_in_past: 'قبلا استفاده شده است'
       equal_to_current_password: 'باید متفاوت با رمز عبور فعلی باشد'
+      equal_to_email: 'باید متفاوت از ایمیل باشد'
       password_complexity:
         digit:
           one: باید حداقل یک رقم داشته باشد

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -3,6 +3,7 @@ fr:
     messages:
       taken_in_past: a été utilisé trop récemment. Veuillez en choisir un autre
       equal_to_current_password: doit être différent de l'actuel
+      equal_to_email: doit être différent de l'e-mail
       password_complexity:
         digit:
           one: doit contenir au moins un chiffre

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -4,6 +4,7 @@ hi:
     messages:
       taken_in_past: यह पासवर्ड, आपके द्वारा पूर्व मे प्रयोग किया जा चुका है  
       equal_to_current_password: नया पासवर्ड, वर्तमान पासवर्ड से भिन्न होना चाहिए 
+      equal_to_email: ईमेल से अलग होना चाहिए
       password_complexity:
         digit:
           one: एक अंक होना चाहिए 

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -3,6 +3,7 @@ it:
     messages:
       taken_in_past: "è stata gia' utilizzata in passato!"
       equal_to_current_password: " deve essere differente dalla password corrente!"
+      equal_to_email: "deve essere differente dall'email"
       password_complexity:
         digit:
           one: deve contenere almeno una cifra

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -3,6 +3,7 @@ ja:
     messages:
       taken_in_past: 'は既に使われています。'
       equal_to_current_password: 'は現在のパスワードと異なるものである必要があります。'
+      equal_to_email: 'メールとは異なる必要があります'
       password_complexity:
         digit:
           one: は最低1つの数字を含む必要があります。

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -3,6 +3,7 @@ nl:
     messages:
       taken_in_past: is eerder gebruikt.
       equal_to_current_password: moet verschillen van het huidige wachtwoord.
+      equal_to_email: moet anders zijn dan de e-mail
       password_complexity:
         digit:
           one: moet minimaal 1 cijfer bevatten

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -3,6 +3,7 @@ pt:
     messages:
       taken_in_past: 'foi usada anteriormente.'
       equal_to_current_password: 'deve ser diferente da senha atual.'
+      equal_to_email: 'deve ser diferente do e-mail.'
       password_complexity:
         digit:
           one: deve conter ao menos um dígito

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -3,6 +3,7 @@ ru:
     messages:
       taken_in_past: 'уже ранее использовался.'
       equal_to_current_password: 'должен отличаться от текущего пароля.'
+      equal_to_email: 'должно отличаться от адреса электронной почты.'
       password_complexity:
         digit:
           one: 'должен содержать хотя бы одну цифру'

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -3,6 +3,7 @@ tr:
     messages:
       taken_in_past: "daha önce kullanıldı."
       equal_to_current_password: "mevcut paroladan farklı olmalı."
+      equal_to_email: "e-postadan farklı olmalı."
       password_format: "büyük, küçük harfler ve sayılar içermeli."
   devise:
     invalid_captcha: "Captcha hatalı."

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -3,6 +3,7 @@ uk:
     messages:
       taken_in_past: 'раніше використовувався.'
       equal_to_current_password: 'має відрізнятися від поточного паролю.'
+      equal_to_email: 'має відрізнятися від електронної пошти.'
       password_complexity:
         digit:
           one: 'повинен включати хоча б одну цифру'

--- a/config/locales/zh_CN.yml
+++ b/config/locales/zh_CN.yml
@@ -3,6 +3,7 @@ zh_CN:
     messages:
       taken_in_past: '曾被使用过。'
       equal_to_current_password: '必须与当前密码不同。'
+      equal_to_email: '必须与电子邮件地址不同。'
       password_complexity:
         digit:
           one: 必须包含至少1个数字

--- a/config/locales/zh_TW.yml
+++ b/config/locales/zh_TW.yml
@@ -3,6 +3,7 @@ zh_TW:
     messages:
       taken_in_past: '曾被使用過。'
       equal_to_current_password: '必須與目前密碼不同。'
+      equal_to_email: '必須與電子郵件地址不同。'
       password_complexity:
         digit:
           one: 必須包含至少一個數字

--- a/lib/devise-security/models/secure_validatable.rb
+++ b/lib/devise-security/models/secure_validatable.rb
@@ -55,6 +55,9 @@ module Devise
 
           # don't allow use same password
           validate :current_equal_password_validation
+
+          # don't allow email to equal password
+          validate :email_not_equal_password_validation
         end
       end
 
@@ -68,6 +71,15 @@ module Devise
           user.password_salt = password_salt_was if respond_to?(:password_salt)
         end
         self.errors.add(:password, :equal_to_current_password) if dummy.valid_password?(password)
+      end
+
+      def email_not_equal_password_validation
+        return if password.blank? || (!new_record? && !will_save_change_to_encrypted_password?)
+        dummy = self.class.new.tap do |user|
+          user.password_salt = password_salt if respond_to?(:password_salt)
+          user.password = email
+        end
+        self.errors.add(:password, :equal_to_email) if dummy.valid_password?(password)
       end
 
       protected

--- a/test/test_secure_validatable.rb
+++ b/test/test_secure_validatable.rb
@@ -82,4 +82,24 @@ class TestSecureValidatable < ActiveSupport::TestCase
     refute user.valid?
     assert_equal DEVISE_ORM == :active_record ? ['Email has already been taken'] : ['Email is already taken'], user.errors.full_messages
   end
+
+  test 'password can not equal email for new user' do
+    msg = 'Password must be different than the email.'
+    user = User.create email: 'bob@microsoft.com', password: 'bob@microsoft.com', password_confirmation: 'bob@microsoft.com'
+    assert_equal(false, user.valid?)
+    assert_includes(user.errors.full_messages, msg)
+    assert_raises(ORMInvalidRecordException) { user.save! }
+  end
+
+  test 'password can not equal email for existing user' do
+    user = User.create email: 'bob@microsoft.com', password: 'pAs5W0rd!Is5e6Ure', password_confirmation: 'pAs5W0rd!Is5e6Ure'
+
+    msg = 'Password must be different than the email.'
+    user.password = 'bob@microsoft.com'
+    user.password_confirmation = 'bob@microsoft.com'
+    user.save
+    assert_equal(false, user.valid?)
+    assert_includes(user.errors.full_messages, msg)
+    assert_raises(ORMInvalidRecordException) { user.save! }
+  end
 end


### PR DESCRIPTION
This simple validation protects against a very simple password which an
attacker would be able to fairly simply guess or attempt. It's a bad
practice, so let's make sure that it's not possible to set such a
password :).